### PR TITLE
Remove some unsafe blocks

### DIFF
--- a/src/ordered_skiplist.rs
+++ b/src/ordered_skiplist.rs
@@ -1390,12 +1390,8 @@ unsafe impl<T: Sync> Sync for OrderedSkipList<T> {}
 impl<T> ops::Drop for OrderedSkipList<T> {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let node: *mut SkipNode<T> = mem::transmute_copy(&self.head);
-
-            while let Some(ref mut next) = (*node).next {
-                mem::replace(&mut (*node).next, mem::replace(&mut next.next, None));
-            }
+        while let Some(mut node) = self.head.next.take() {
+            self.head.next = node.next.take();
         }
     }
 }

--- a/src/ordered_skiplist.rs
+++ b/src/ordered_skiplist.rs
@@ -242,16 +242,8 @@ impl<T> OrderedSkipList<T> {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        unsafe {
-            let node: *mut SkipNode<T> = mem::transmute_copy(&self.head);
-
-            while let Some(ref mut next) = (*node).next {
-                mem::replace(&mut (*node).next, mem::replace(&mut next.next, None));
-            }
-        }
-        let new_head = Box::new(SkipNode::head(self.level_generator.total()));
         self.len = 0;
-        mem::replace(&mut self.head, new_head);
+        *self.head = SkipNode::head(self.level_generator.total());
     }
 
     /// Returns the number of elements in the skiplist.
@@ -1390,15 +1382,6 @@ where
 
 unsafe impl<T: Send> Send for OrderedSkipList<T> {}
 unsafe impl<T: Sync> Sync for OrderedSkipList<T> {}
-
-impl<T> ops::Drop for OrderedSkipList<T> {
-    #[inline]
-    fn drop(&mut self) {
-        while let Some(mut node) = self.head.next.take() {
-            self.head.next = node.next.take();
-        }
-    }
-}
 
 impl<T: PartialOrd> default::Default for OrderedSkipList<T> {
     fn default() -> OrderedSkipList<T> {

--- a/src/ordered_skiplist.rs
+++ b/src/ordered_skiplist.rs
@@ -2,11 +2,11 @@
 
 use crate::{
     level_generator::{GeometricalLevelGenerator, LevelGenerator},
-    skipnode::SkipNode,
+    skipnode::{IntoIter, SkipNode},
 };
 use std::{
     cmp, cmp::Ordering, default, fmt, hash, hash::Hash, iter, marker::PhantomData, mem, ops,
-    ops::Bound,
+    ops::Bound, ptr,
 };
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -978,13 +978,17 @@ impl<T> OrderedSkipList<T> {
     /// }
     /// ```
     #[allow(clippy::should_implement_trait)]
-    pub fn into_iter(self) -> IntoIter<T> {
-        IntoIter {
-            head: unsafe { mem::transmute_copy(&self.head) },
-            end: self.get_last() as *mut SkipNode<T>,
-            size: self.len(),
-            skiplist: self,
+    pub fn into_iter(mut self) -> IntoIter<T> {
+        let mut last = self.get_last() as *mut SkipNode<T>;
+        if last == &mut *self.head {
+            last = ptr::null_mut();
         }
+        let size = self.len();
+        let first = self.head.next.take().map(|mut node| {
+            node.prev = None;
+            node
+        });
+        IntoIter { first, last, size }
     }
 
     /// Creates an iterator over the entries of the skiplist.
@@ -1595,71 +1599,6 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
                 }
                 self.end = prev;
                 return (*node).value.as_ref();
-            }
-            None
-        }
-    }
-}
-
-/// Consuming terator for a [`OrderedSkipList`].  
-pub struct IntoIter<T> {
-    skiplist: OrderedSkipList<T>,
-    head: *mut SkipNode<T>,
-    end: *mut SkipNode<T>,
-    size: usize,
-}
-
-impl<T> Iterator for IntoIter<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        unsafe {
-            if let Some(next) = (*self.head).links[0] {
-                for lvl in 0..self.skiplist.level_generator.total() {
-                    if lvl <= (*next).level {
-                        (*self.head).links[lvl] = (*next).links[lvl];
-                        (*self.head).links_len[lvl] = (*next).links_len[lvl] - 1;
-                    } else {
-                        (*self.head).links_len[lvl] -= 1;
-                    }
-                }
-                if let Some(next) = (*self.head).links[0] {
-                    (*next).prev = Some(self.head);
-                }
-                self.skiplist.len -= 1;
-                self.size -= 1;
-                let popped_node = mem::replace(
-                    &mut (*self.head).next,
-                    mem::replace(&mut (*next).next, None),
-                );
-                popped_node.expect("Should have a node").value
-            } else {
-                None
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.size, Some(self.size))
-    }
-}
-
-impl<T> DoubleEndedIterator for IntoIter<T> {
-    fn next_back(&mut self) -> Option<T> {
-        unsafe {
-            if self.head == self.end {
-                return None;
-            }
-            if let Some(prev) = (*self.end).prev {
-                if prev as *const SkipNode<T> != self.head {
-                    self.size -= 1;
-                } else {
-                    self.size = 0;
-                }
-                self.end = prev;
-                (*self.end).links[0] = None;
-                let node = mem::replace(&mut (*self.end).next, None);
-                return node.unwrap().into_inner();
             }
             None
         }

--- a/src/skiplist.rs
+++ b/src/skiplist.rs
@@ -88,16 +88,8 @@ impl<T> SkipList<T> {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        unsafe {
-            let node: *mut SkipNode<T> = mem::transmute_copy(&self.head);
-
-            while let Some(ref mut next) = (*node).next {
-                mem::replace(&mut (*node).next, mem::replace(&mut next.next, None));
-            }
-        }
-        let new_head = Box::new(SkipNode::head(self.level_generator.total()));
         self.len = 0;
-        mem::replace(&mut self.head, new_head);
+        *self.head = SkipNode::head(self.level_generator.total());
     }
 
     /// Returns the number of elements in the skiplist.
@@ -1113,15 +1105,6 @@ where
 
 unsafe impl<T: Send> Send for SkipList<T> {}
 unsafe impl<T: Sync> Sync for SkipList<T> {}
-
-impl<T> ops::Drop for SkipList<T> {
-    #[inline]
-    fn drop(&mut self) {
-        while let Some(mut node) = self.head.next.take() {
-            self.head.next = node.next.take();
-        }
-    }
-}
 
 impl<T: PartialOrd> default::Default for SkipList<T> {
     fn default() -> SkipList<T> {

--- a/src/skiplist.rs
+++ b/src/skiplist.rs
@@ -1113,12 +1113,8 @@ unsafe impl<T: Sync> Sync for SkipList<T> {}
 impl<T> ops::Drop for SkipList<T> {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let node: *mut SkipNode<T> = mem::transmute_copy(&self.head);
-
-            while let Some(ref mut next) = (*node).next {
-                mem::replace(&mut (*node).next, mem::replace(&mut next.next, None));
-            }
+        while let Some(mut node) = self.head.next.take() {
+            self.head.next = node.next.take();
         }
     }
 }

--- a/src/skipmap.rs
+++ b/src/skipmap.rs
@@ -1286,12 +1286,8 @@ unsafe impl<K: Sync, V: Sync> Sync for SkipMap<K, V> {}
 impl<K, V> ops::Drop for SkipMap<K, V> {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let node: *mut SkipNode<K, V> = mem::transmute_copy(&self.head);
-
-            while let Some(ref mut next) = (*node).next {
-                mem::replace(&mut (*node).next, mem::replace(&mut next.next, None));
-            }
+        while let Some(mut node) = self.head.next.take() {
+            self.head.next = node.next.take();
         }
     }
 }

--- a/src/skipnode.rs
+++ b/src/skipnode.rs
@@ -69,17 +69,21 @@ impl<V> SkipNode<V> {
     }
 
     /// Consumes the node returning the value it contains.
-    pub fn into_inner(self) -> Option<V> {
-        if self.value.is_some() {
-            Some(self.value.unwrap())
-        } else {
-            None
-        }
+    pub fn into_inner(mut self) -> Option<V> {
+        self.value.take()
     }
 
     /// Returns `true` is the node is a head-node.
     pub fn is_head(&self) -> bool {
         self.prev.is_none()
+    }
+}
+
+impl<V> Drop for SkipNode<V> {
+    fn drop(&mut self) {
+        while let Some(mut node) = self.next.take() {
+            self.next = node.next.take();
+        }
     }
 }
 


### PR DESCRIPTION
I saw issue #10 and tried to remove some unsafe blocks that are easy to remove.

They are IntoIter::next() and clear().