### PR TITLE
Fix warnings and outdated CI

### DIFF
--- a/.github/workflows/rust-audit-cron.yml
+++ b/.github/workflows/rust-audit-cron.yml
@@ -6,7 +6,5 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/audit-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v3
+    - run: cargo audit

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -8,7 +8,5 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/audit-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v3
+    - run: cargo audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,75 +3,40 @@ name: Rust
 on: [push, pull_request]
 
 jobs:
-  check:
+  fmt:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain: [stable, beta, nightly]
     steps:
-      - uses: actions/checkout@v1
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          components: rustfmt, clippy
-      - name: format
-        # switch to `action-rs/rustfmt-check` once that is available
-        uses: actions-rs/cargo@v1
+          components: rustfmt
+      - run: cargo fmt --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          command: fmt
-          args: >-
-            --
-            --check
-      - name: clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: clippy-${{ matrix.toolchain }}
-          args: >-
-            --bins
-            --examples
-            --tests
-            --benches
-            --
-            -W missing_docs
+          components: clippy
+      - run: cargo clippy --workspace
 
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain: [stable, beta, nightly]
     steps:
-      - uses: actions/checkout@v1
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-      - name: test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-      - name: bench
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: >-
-            --benches
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --workspace
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
         with:
-          toolchain: stable
-          override: true
-      - name: tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-      - name: upload
-        uses: codecov/codecov-action@v1
+          tool: cargo-tarpaulin
+      - run: cargo tarpaulin
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/skiplist.svg)](https://crates.io/crates/skiplist)
 [![crates.io](https://img.shields.io/crates/d/skiplist.svg)](https://crates.io/crates/skiplist)
 [![Codecov branch](https://img.shields.io/codecov/c/github/JP-Ellis/rust-skiplist/master)](https://codecov.io/gh/JP-Ellis/rust-skiplist)
-[![Build Status](https://img.shields.io/github/workflow/status/JP-Ellis/rust-skiplist/Rust/master.svg)](https://github.com/JP-Ellis/rust-skiplist/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/JP-Ellis/rust-skiplist/rust.yml?branch=master)](https://github.com/JP-Ellis/rust-skiplist/actions)
 
 A [skiplist](http://en.wikipedia.org/wiki/Skip_list) provides a way of storing
 data with `log(i)` access, insertion and removal for an element in the `i`th

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -9,7 +9,7 @@ mod skipmap;
 mod vec;
 mod vecdeque;
 
-/// Group Benchmarks
+// Group Benchmarks
 criterion_group!(
     name = benches;
     config = Criterion::default();
@@ -45,5 +45,5 @@ criterion_group!(
     crate::vecdeque::rand_access,
 );
 
-/// Benchmarks
+// Benchmarks
 criterion_main!(benches);

--- a/src/ordered_skiplist.rs
+++ b/src/ordered_skiplist.rs
@@ -39,6 +39,7 @@ pub struct OrderedSkipList<T> {
     head: Box<SkipNode<T>>,
     len: usize,
     level_generator: GeometricalLevelGenerator,
+    #[allow(clippy::type_complexity)]
     compare: Box<dyn Fn(&T, &T) -> Ordering>,
 }
 

--- a/src/ordered_skiplist.rs
+++ b/src/ordered_skiplist.rs
@@ -663,7 +663,8 @@ impl<T> OrderedSkipList<T> {
     /// assert_eq!(skiplist.lower_bound(Excluded(&10)), None);
     /// ```
     pub fn lower_bound(&self, min: Bound<&T>) -> Option<&T> {
-        self._lower_bound(min).and_then(|(node, _)| node.item.as_ref())
+        self._lower_bound(min)
+            .and_then(|(node, _)| node.item.as_ref())
     }
 
     /// Returns an `Option<&T>` pointing to the highest element whose key is above

--- a/src/skiplist.rs
+++ b/src/skiplist.rs
@@ -761,7 +761,7 @@ where
                         dashes.push('-');
                     }
 
-                    if lvl <= (*node).level {
+                    if lvl <= node.level {
                         rows[lvl].push_str(value_len.as_ref());
                     } else {
                         rows[lvl].push_str(dashes.as_ref());

--- a/src/skipmap.rs
+++ b/src/skipmap.rs
@@ -1027,7 +1027,7 @@ where
     }
 }
 
-impl<'a, K, V> ops::Index<usize> for SkipMap<K, V> {
+impl<K, V> ops::Index<usize> for SkipMap<K, V> {
     type Output = V;
 
     fn index(&self, index: usize) -> &V {
@@ -1037,7 +1037,7 @@ impl<'a, K, V> ops::Index<usize> for SkipMap<K, V> {
     }
 }
 
-impl<'a, K, V> ops::IndexMut<usize> for SkipMap<K, V> {
+impl<K, V> ops::IndexMut<usize> for SkipMap<K, V> {
     fn index_mut(&mut self, index: usize) -> &mut V {
         self.get_index_mut(index)
             .and_then(|node| node.value_mut())

--- a/src/skipnode.rs
+++ b/src/skipnode.rs
@@ -1138,7 +1138,7 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
             return None;
         }
         assert!(
-            !self.last.is_none(),
+            self.last.is_some(),
             "The IntoIter should be empty but IntoIter.last somehow still contains something"
         );
         let popped_node = if ptr::eq(self.first.as_deref().as_ptr(), self.last.unwrap().as_ptr()) {


### PR DESCRIPTION
While the title says it all, there's something to be clear about modifying CI.

- Stopped using actions-rs and replaced it with alternatives.\
actions-rs hasn't been updated in a very long time, and you'll get a warning every time your workflow runs that it's using an outdated version of Node.js. Some actions will even throw an error.