### PR TITLE
Fix "unusable report" error on Codecov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-tarpaulin
-      - run: cargo tarpaulin
+      - run: cargo tarpaulin --workspace --out Xml
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Currently, CI is not generating cobertura.xml and this seems to be causing the "unusable report" error on Codecov. So I modified the command line arguments being passed to tarpaulin.