### PR TITLE
chore(ci): remove pre-commit cache restore key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,8 +266,6 @@ jobs:
           path: |
             ${{ env.PRE_COMMIT_HOME }}
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Pre-commit does not clean up any files, resulting in the cache bloating indefinitely.