### PR TITLE
fix: preserve container invariants when user code unwinds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,8 @@ pub mod ordered_skip_list;
 pub mod skip_list;
 pub mod skip_map;
 pub mod skip_set;
+#[cfg(test)]
+mod test_util;
 
 #[cfg(feature = "partial-ord")]
 pub use comparator::PartialOrdComparator;

--- a/src/node.rs
+++ b/src/node.rs
@@ -457,36 +457,6 @@ impl<V, const N: usize> Node<V, N> {
         unsafe { Box::from_raw(self) }
     }
 
-    /// Drops all nodes following `self` and sets `self.next` to `None`.
-    ///
-    /// This is an `$O(k)$` iterative operation, where k is the number of nodes
-    /// freed.  The caller is responsible for clearing any skip links that
-    /// pointed to the freed nodes before or after this call.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that no live references (including non-owning
-    /// skip-link pointers that will be dereferenced) to the nodes being freed
-    /// remain after this call.
-    #[inline]
-    pub(crate) unsafe fn truncate_next(&mut self) {
-        // Same iterative pattern as `Drop for Node<V>`, applied to the tail
-        // of the chain rather than the node itself.
-        let mut current = self.next.take();
-        while let Some(ptr) = current {
-            // SAFETY: Every node reachable via `next` was heap-allocated via
-            // `Box::new` and then stored via `Box::into_raw` in
-            // `insert_after`.  We take ownership by removing the pointer from
-            // the previous node's `next` before reconstructing the `Box`, so
-            // no other owner exists.
-            let mut boxed: Box<Self> = unsafe { Box::from_raw(ptr.as_ptr()) };
-            current = boxed.next.take();
-            // Drop `boxed` here.  Because `next` was already taken, the
-            // node's own `Drop` impl will do nothing further.
-            drop(boxed);
-        }
-    }
-
     /// Joins a head node to a tail node, creating a single sequence of nodes.
     ///
     /// This method takes ownership of `head` (consuming it) and splices the
@@ -629,6 +599,57 @@ impl<V, const N: usize> Node<V, N> {
         self.next = Some(first);
     }
 
+    /// Frees `first` and every node that follows it.
+    ///
+    /// Each node's `next` is taken before the node is freed, so this is
+    /// `$O(k)$` and non-recursive in the number of nodes freed.
+    ///
+    /// Freeing a node runs its element's destructor, which may unwind.  The
+    /// nodes not yet freed are then re-attached after `attach` and every skip
+    /// link is rebuilt, so the container keeps the elements it has not
+    /// destroyed instead of leaking them.  `out_len` and `out_tail`
+    /// describe that survivor chain and are written on the unwind path
+    /// alone; the normal path frees everything and leaves both untouched.
+    ///
+    /// # Safety
+    ///
+    /// - The caller must commit the container's post-call length and tail
+    ///   before calling.  Nothing is published unless an element destructor
+    ///   unwinds, so a caller that defers the update leaves `tail` pointing
+    ///   into the region this call frees.
+    /// - `head` must be the exclusively-owned head sentinel of the container.
+    /// - `attach` must be a live node in that container with `next == None`,
+    ///   and must be the node the chain hung off before it was detached.
+    /// - `first`, and every node reachable from it, must have been allocated
+    ///   via `Box::into_raw` and detached from the container, with no other
+    ///   live reference to any of them.
+    #[inline]
+    pub(crate) unsafe fn drop_chain(
+        head: NonNull<Self>,
+        attach: NonNull<Self>,
+        out_len: &mut usize,
+        out_tail: &mut Option<NonNull<Self>>,
+        first: Option<NonNull<Self>>,
+    ) {
+        let mut walk = DropChain {
+            head,
+            attach,
+            current: first,
+            out_len,
+            out_tail,
+        };
+
+        while let Some(ptr) = walk.current {
+            // SAFETY: every node in the chain was allocated by `Box::into_raw`
+            // and detached from the container, so this `Box` is its only owner.
+            let mut boxed: Box<Self> = unsafe { Box::from_raw(ptr.as_ptr()) };
+            // Commit the advance before the element's destructor runs, and
+            // leave the node's own `next` empty so its `Drop` stops here.
+            walk.current = boxed.next.take();
+            drop(boxed);
+        }
+    }
+
     /// Filter and rebuild skip links in a single `$O(n)$` forward pass.
     ///
     /// Walks the `next` chain starting from `head` (the head sentinel).
@@ -639,9 +660,17 @@ impl<V, const N: usize> Node<V, N> {
     /// - If `keep(raw_ptr)` returns `false`, `on_drop(boxed_node)` is called
     ///   and the node is removed from the chain.
     ///
-    /// Returns `(new_len, new_tail)` where `new_len` is the count of retained
-    /// nodes and `new_tail` is the last retained node, or `None` if all nodes
-    /// were removed.
+    /// `out_len` receives the count of retained nodes and `out_tail` the last
+    /// retained node, or `None` if all nodes were removed.
+    ///
+    /// Both `keep` and `on_drop` run caller code that may unwind: `keep` is a
+    /// user predicate, and `on_drop` runs the element's destructor.  The
+    /// results are written through `out_len` and `out_tail` rather than
+    /// returned so that the walk can publish them on the unwind path too,
+    /// where a returned value would be discarded.  A panic therefore cannot
+    /// leave the container claiming nodes the walk has already freed.  Every
+    /// node the walk had not yet reached is retained, as is the node `keep`
+    /// panicked on.
     ///
     /// # Safety
     ///
@@ -653,101 +682,201 @@ impl<V, const N: usize> Node<V, N> {
     ///   insertion, removal, or pointer update).  It may read or mutate node
     ///   values before returning.
     #[expect(
-        clippy::expect_used,
-        reason = "Link::new(dist) returns Err only when dist == 0; \
-                  dist = new_rank - pred_rank and new_rank > pred_rank \
-                  whenever a predecessor is recorded, so dist >= 1 always"
-    )]
-    #[expect(
-        clippy::indexing_slicing,
-        reason = "l < node_height <= max_levels = predecessors.len() = self.level(); \
-                  l indexes both predecessors[l] and links_mut()[l] so a plain index \
-                  loop is the clearest expression"
-    )]
-    #[expect(
         clippy::multiple_unsafe_ops_per_block,
-        reason = "raw-pointer traversal, link clearing, optional pop, and link wiring \
-                  all touch provably disjoint heap nodes; grouping them avoids \
-                  unsafe-crossing raw-pointer variables"
+        reason = "raw-pointer traversal, link clearing and the optional pop all touch \
+                  provably disjoint heap nodes; grouping them avoids unsafe-crossing \
+                  raw-pointer variables"
     )]
     pub(crate) unsafe fn filter_rebuild<F, D>(
         head: NonNull<Self>,
+        out_len: &mut usize,
+        out_tail: &mut Option<NonNull<Self>>,
         mut keep: F,
         mut on_drop: D,
-    ) -> (usize, Option<NonNull<Self>>)
-    where
+    ) where
         F: FnMut(*mut Self) -> bool,
         D: FnMut(Box<Self>),
     {
         let head_ptr: *mut Self = head.as_ptr();
         // SAFETY: head is a valid, exclusively-owned head sentinel per the
         // function's safety contract.
-        let max_levels = unsafe { (*head_ptr).level() };
-        let mut predecessors: ArrayVec<(*mut Self, usize), N> =
-            iter::repeat_n((head_ptr, 0_usize), max_levels).collect();
-        let mut new_rank: usize = 0;
-        let mut new_tail: Option<NonNull<Self>> = None;
-
-        // SAFETY: head_ptr and all nodes reachable via next are live,
-        // exclusively-owned, heap-allocated Node<V> instances.  `keep` does
-        // not structurally modify the chain before returning.
-        unsafe {
+        let (max_levels, first) = unsafe {
             for link in (*head_ptr).links_mut() {
                 *link = None;
             }
+            ((*head_ptr).level(), (*head_ptr).next())
+        };
 
-            let mut current_opt = (*head_ptr).next();
-            while let Some(cur_nn) = current_opt {
-                let cur: *mut Self = cur_nn.as_ptr();
-                // Save successor before any structural mutation.
-                let next_opt = (*cur).next();
+        let mut walk = Rebuild {
+            predecessors: iter::repeat_n((head_ptr, 0_usize), max_levels).collect(),
+            rank: 0,
+            tail: None,
+            current: first,
+            out_len,
+            out_tail,
+        };
 
-                if keep(cur) {
-                    new_rank = new_rank.saturating_add(1);
-                    new_tail = Some(cur_nn);
+        while let Some(cur_nn) = walk.current {
+            let cur: *mut Self = cur_nn.as_ptr();
+            // SAFETY: cur is a live, exclusively-owned data node in the chain.
+            // Read the successor before any structural mutation.
+            let next = unsafe { (*cur).next() };
 
-                    // Clear this node's forward links; they will be re-wired.
-                    for link in (*cur).links_mut() {
-                        *link = None;
-                    }
-
-                    let height = (*cur).level();
-                    for l in 0..height {
-                        let (pred_ptr, pred_rank) = predecessors[l];
-                        let dist = new_rank.saturating_sub(pred_rank);
-                        (*pred_ptr).links_mut()[l] = Some(
-                            Link::new(NonNull::new_unchecked(cur), dist)
-                                .expect("dist >= 1 by construction"),
-                        );
-                        predecessors[l] = (cur, new_rank);
-                    }
-                } else {
-                    on_drop((*cur).pop());
-                }
-
-                current_opt = next_opt;
+            // `keep` may unwind.  Leaving `walk.current` on `cur` until it
+            // returns makes the guard retain `cur` along with the rest.
+            if keep(cur) {
+                walk.current = next;
+                // SAFETY: cur is live and still linked into the chain.
+                unsafe { walk.retain(cur_nn) };
+            } else {
+                // The element's destructor may unwind, so commit the advance
+                // before `cur` is unlinked and destroyed.
+                walk.current = next;
+                // SAFETY: cur is a live data node; `pop` detaches it from the
+                // chain and transfers ownership to the returned Box.
+                on_drop(unsafe { (*cur).pop() });
             }
         }
 
-        (new_rank, new_tail)
+        // Dropping `walk` publishes the length and tail.
     }
+}
 
-    /// Rebuilds all skip links in a single `$O(n)$` forward pass, retaining every
-    /// node.
-    ///
-    /// This is the keep-all specialisation of [`filter_rebuild`](Self::filter_rebuild).
-    /// Returns the last data node as a [`NonNull`], or `None` if the chain is empty.
+/// Incremental state of a [`Node::drop_chain`] walk.
+///
+/// Dropping the guard re-attaches the nodes the walk has not yet freed and
+/// rebuilds every skip link, so an element destructor that unwinds leaves its
+/// surviving neighbours owned by the container rather than stranded.
+struct DropChain<'a, V, const N: usize> {
+    /// Head sentinel of the container, used to rebuild the skip links.
+    head: NonNull<Node<V, N>>,
+    /// Node the survivors are re-attached after.  Its `next` is `None` for as
+    /// long as the walk runs.
+    attach: NonNull<Node<V, N>>,
+    /// Next node to free, or `None` once the chain is exhausted.
+    current: Option<NonNull<Node<V, N>>>,
+    /// Container length to publish into.
+    out_len: &'a mut usize,
+    /// Container tail to publish into.
+    out_tail: &'a mut Option<NonNull<Node<V, N>>>,
+}
+
+impl<V, const N: usize> Drop for DropChain<'_, V, N> {
+    #[expect(
+        clippy::multiple_unsafe_ops_per_block,
+        reason = "re-attaching the survivors and rebuilding the links are one recovery \
+                  step on the same chain; splitting them would obscure that"
+    )]
+    fn drop(&mut self) {
+        let Some(first) = self.current.take() else {
+            return;
+        };
+
+        // SAFETY: `first` heads a chain of live, exclusively-owned nodes whose
+        // predecessor has already been freed, and `attach.next` is None.
+        // `set_head_next` overwrites `first.prev`, so the freed predecessor is
+        // never read.  Re-attaching only rewires pointers and rebuilding only
+        // retains, so neither can unwind a second time.
+        unsafe {
+            (*self.attach.as_ptr()).set_head_next(first);
+            Node::filter_rebuild(self.head, self.out_len, self.out_tail, |_| true, |_| {});
+        }
+    }
+}
+
+/// Incremental state of a [`Node::filter_rebuild`] walk.
+///
+/// Dropping the guard retains every node the walk has not yet reached and
+/// publishes the resulting length and tail, so the `next` chain, the skip
+/// links and the container's bookkeeping agree on every exit path — including
+/// an unwind out of the predicate or out of an element's destructor.
+struct Rebuild<'a, V, const N: usize> {
+    /// Last node wired at each level, paired with its rank in the rebuilt
+    /// list.  Level `l` starts at the head sentinel with rank 0.
+    predecessors: ArrayVec<(*mut Node<V, N>, usize), N>,
+    /// Number of nodes retained so far.
+    rank: usize,
+    /// Last node retained so far.
+    tail: Option<NonNull<Node<V, N>>>,
+    /// Next node to visit, or `None` once the chain is exhausted.
+    current: Option<NonNull<Node<V, N>>>,
+    /// Container length to publish into.
+    out_len: &'a mut usize,
+    /// Container tail to publish into.
+    out_tail: &'a mut Option<NonNull<Node<V, N>>>,
+}
+
+impl<V, const N: usize> Rebuild<'_, V, N> {
+    /// Wires `cur` into the rebuilt list as the next retained node.
     ///
     /// # Safety
     ///
-    /// Same as [`filter_rebuild`](Self::filter_rebuild): `head` must be the
-    /// exclusively-owned head sentinel of a valid prev/next chain, with no
-    /// other live references to any node in the chain.
-    #[inline]
-    pub(crate) unsafe fn rebuild(head: NonNull<Self>) -> Option<NonNull<Self>> {
-        // SAFETY: forwarded from caller.
-        let (_, tail) = unsafe { Self::filter_rebuild(head, |_| true, |_| {}) };
-        tail
+    /// `cur` must be a live, exclusively-owned data node still linked into the
+    /// chain, and every pointer in `predecessors` must still be live.
+    #[expect(
+        clippy::expect_used,
+        reason = "Link::new(dist) returns Err only when dist == 0; \
+                  dist = rank - pred_rank and rank > pred_rank whenever a \
+                  predecessor is recorded, so dist >= 1 always"
+    )]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "l < node_height <= max_levels = predecessors.len() = head.level(); \
+                  l indexes both predecessors[l] and links_mut()[l] so a plain index \
+                  loop is the clearest expression"
+    )]
+    #[expect(
+        clippy::multiple_unsafe_ops_per_block,
+        reason = "link clearing and link wiring touch provably disjoint heap nodes; \
+                  grouping them avoids unsafe-crossing raw-pointer variables"
+    )]
+    unsafe fn retain(&mut self, cur: NonNull<Node<V, N>>) {
+        let ptr: *mut Node<V, N> = cur.as_ptr();
+        self.rank = self.rank.saturating_add(1);
+        self.tail = Some(cur);
+
+        // SAFETY: ptr and every recorded predecessor are live, exclusively
+        // owned, heap-allocated nodes.
+        unsafe {
+            // Clear this node's forward links; they are re-wired below.
+            for link in (*ptr).links_mut() {
+                *link = None;
+            }
+
+            let height = (*ptr).level();
+            for l in 0..height {
+                let (pred_ptr, pred_rank) = self.predecessors[l];
+                let dist = self.rank.saturating_sub(pred_rank);
+                (*pred_ptr).links_mut()[l] =
+                    Some(Link::new(cur, dist).expect("dist >= 1 by construction"));
+                self.predecessors[l] = (ptr, self.rank);
+            }
+        }
+    }
+
+    /// Retains every node the walk has not yet reached.
+    ///
+    /// # Safety
+    ///
+    /// Every node reachable from `current` must be live and exclusively owned.
+    unsafe fn retain_rest(&mut self) {
+        while let Some(cur) = self.current {
+            // SAFETY: cur is a live, exclusively-owned data node in the chain.
+            self.current = unsafe { (*cur.as_ptr()).next() };
+            // SAFETY: cur is live and still linked into the chain.
+            unsafe { self.retain(cur) };
+        }
+    }
+}
+
+impl<V, const N: usize> Drop for Rebuild<'_, V, N> {
+    fn drop(&mut self) {
+        // SAFETY: every node still reachable from `current` is live and
+        // exclusively owned by the container being rebuilt.  Retaining a node
+        // only rewires links, so this cannot unwind a second time.
+        unsafe { self.retain_rest() };
+        *self.out_len = self.rank;
+        *self.out_tail = self.tail;
     }
 }
 
@@ -1352,8 +1481,16 @@ pub(crate) mod tests {
     #[rstest]
     fn filter_rebuild_empty_list() {
         let mut head = Box::new(Node::<u8, MAX_LEVELS>::new(MAX_LEVELS));
-        let (new_len, new_tail) =
-            unsafe { Node::filter_rebuild(NonNull::from_mut(&mut *head), |_| true, |_| {}) };
+        let (mut new_len, mut new_tail) = (0, None);
+        unsafe {
+            Node::filter_rebuild(
+                NonNull::from_mut(&mut *head),
+                &mut new_len,
+                &mut new_tail,
+                |_| true,
+                |_| {},
+            );
+        }
         assert_eq!(new_len, 0);
         assert!(new_tail.is_none());
         assert!(head.next_as_ref().is_none());
@@ -1362,7 +1499,8 @@ pub(crate) mod tests {
     #[rstest]
     fn filter_rebuild_keep_all(skiplist: Result<NonNull<Node<u8, MAX_LEVELS>>>) -> Result<()> {
         let head = skiplist?;
-        let (new_len, new_tail) = unsafe { Node::filter_rebuild(head, |_| true, |_| {}) };
+        let (mut new_len, mut new_tail) = (0, None);
+        unsafe { Node::filter_rebuild(head, &mut new_len, &mut new_tail, |_| true, |_| {}) };
 
         assert_eq!(new_len, 4);
         let vals: Vec<u8> = {
@@ -1410,13 +1548,16 @@ pub(crate) mod tests {
     fn filter_rebuild_keep_none(skiplist: Result<NonNull<Node<u8, MAX_LEVELS>>>) -> Result<()> {
         let mut dropped_vals: Vec<u8> = Vec::new();
         let head = skiplist?;
-        let (new_len, new_tail) = unsafe {
+        let (mut new_len, mut new_tail) = (0, None);
+        unsafe {
             Node::filter_rebuild(
                 head,
+                &mut new_len,
+                &mut new_tail,
                 |_| false,
                 |mut b| dropped_vals.push(b.take_value().expect("data node")),
-            )
-        };
+            );
+        }
 
         assert_eq!(new_len, 0);
         assert!(new_tail.is_none());
@@ -1450,16 +1591,19 @@ pub(crate) mod tests {
     ) -> Result<()> {
         // Keep v1 (value 10) and v3 (value 30); drop v2 and v4.
         let head = skiplist?;
-        let (new_len, new_tail) = unsafe {
+        let (mut new_len, mut new_tail) = (0, None);
+        unsafe {
             Node::filter_rebuild(
                 head,
+                &mut new_len,
+                &mut new_tail,
                 |cur| {
                     let v = (*cur).value().copied();
                     v == Some(10) || v == Some(30)
                 },
                 |_| {},
-            )
-        };
+            );
+        }
 
         assert_eq!(new_len, 2);
         let vals: Vec<u8> = {
@@ -1509,6 +1653,8 @@ pub(crate) mod tests {
         unsafe {
             Node::filter_rebuild(
                 head,
+                &mut 0,
+                &mut None,
                 |cur| {
                     let v = (*cur).value().copied();
                     v == Some(20) || v == Some(40)
@@ -1534,6 +1680,8 @@ pub(crate) mod tests {
         unsafe {
             Node::filter_rebuild(
                 head,
+                &mut 0,
+                &mut None,
                 |cur| {
                     let v = (*cur).value().copied();
                     v != Some(20) && v != Some(30)
@@ -1595,7 +1743,7 @@ pub(crate) mod tests {
         //   v3.links[0]   → None             (v4 has height 0 so nothing wires into v3.links[0])
         let head = skiplist?;
         unsafe {
-            Node::filter_rebuild(head, |_| true, |_| {});
+            Node::filter_rebuild(head, &mut 0, &mut None, |_| true, |_| {});
         }
 
         let link0 = unsafe { head.as_ref() }.links()[0]
@@ -1772,90 +1920,6 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    // MARK: truncate_next
-
-    #[test]
-    fn truncate_next_on_middle_node() -> Result<()> {
-        // Build head → v1(10) → v2(20) → v3(30), all height 0 (no skip links).
-        let mut head = Box::new(Node::<u8, MAX_LEVELS>::new(MAX_LEVELS));
-        unsafe {
-            Node::insert_after(NonNull::from_mut(&mut *head), Node::with_value(0, 10_u8));
-            Node::insert_after(
-                NonNull::from_mut(head.next_as_mut().expect("v1")),
-                Node::with_value(0, 20_u8),
-            );
-            Node::insert_after(
-                NonNull::from_mut(head.next_as_mut().expect("v1").next_as_mut().expect("v2")),
-                Node::with_value(0, 30_u8),
-            );
-        }
-
-        // Truncate after v1; v2 and v3 are freed.
-        // SAFETY: v1 is exclusively owned and no other references to v2/v3 exist.
-        unsafe { head.next_as_mut().expect("v1").truncate_next() };
-
-        let vals: Vec<u8> = {
-            let mut v = Vec::new();
-            let mut cur = head.next_as_ref();
-            while let Some(n) = cur {
-                v.push(*n.value().expect("data node"));
-                cur = n.next_as_ref();
-            }
-            v
-        };
-        assert_eq!(vals, [10]);
-
-        // Insta is incompatible with Miri
-        if !cfg!(miri) {
-            assert_snapshot!(
-                head.display()?,
-                @"
-                [03]: 00
-                [02]: 00
-                [01]: 00
-                [->]: 00 -> 01
-                [<-]: 00 <- 01
-
-                [00|03] None
-                [01|00] Some(10)
-                "
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn truncate_next_empties_list() -> Result<()> {
-        // Build head → v1(10), height 0.
-        let mut head = Box::new(Node::<u8, MAX_LEVELS>::new(MAX_LEVELS));
-        unsafe { Node::insert_after(NonNull::from_mut(&mut *head), Node::with_value(0, 10_u8)) };
-
-        // Truncate directly on head; v1 is freed.
-        // SAFETY: head is exclusively owned and no other references to v1 exist.
-        unsafe {
-            head.truncate_next();
-        }
-
-        assert!(head.next_as_ref().is_none());
-
-        // Insta is incompatible with Miri
-        if !cfg!(miri) {
-            assert_snapshot!(
-                head.display()?,
-                @"
-                [03]: 00
-                [02]: 00
-                [01]: 00
-                [->]: 00
-                [<-]: 00
-
-                [00|03] None
-                "
-            );
-        }
-        Ok(())
-    }
-
     // MARK: take_next_chain / set_head_next
 
     #[test]
@@ -1951,9 +2015,10 @@ pub(crate) mod tests {
             cur = unsafe { n.next_as_mut() };
         }
 
+        let mut tail = None;
         // SAFETY: head is exclusively owned; all data nodes are live heap
         // allocations reachable through the next chain.
-        let tail = unsafe { Node::rebuild(head) };
+        unsafe { Node::filter_rebuild(head, &mut 0, &mut tail, |_| true, |_| {}) };
 
         assert_eq!(
             unsafe { tail.expect("non-empty").as_ref() }

--- a/src/ordered_skip_list.rs
+++ b/src/ordered_skip_list.rs
@@ -459,8 +459,7 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     #[inline]
     pub(crate) unsafe fn rebuild_skip_links(&mut self) {
         // SAFETY: caller guarantees all nodes are valid.
-        let (_, new_tail) = unsafe { Node::filter_rebuild(self.head, |_| true, |_| {}) };
-        self.tail = new_tail;
+        unsafe { Node::filter_rebuild(self.head, &mut self.len, &mut self.tail, |_| true, |_| {}) };
     }
 }
 

--- a/src/ordered_skip_list/filter.rs
+++ b/src/ordered_skip_list/filter.rs
@@ -18,6 +18,10 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     ///
     /// This operation is `$O(n)$`: every element is visited once.
     ///
+    /// If `f` or an element's destructor panics, the elements the walk had
+    /// not yet reached are kept in the list, as is the element `f` panicked
+    /// on; the list stays usable.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -55,18 +59,21 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
         // this OrderedSkipList.  We hold &mut self so no other reference to
         // any node exists.  The closure reads the value and returns before any
         // structural mutation occurs.
-        let (new_rank, new_tail) = unsafe {
+        // `filter_rebuild` publishes the new length and tail itself, so
+        // an unwind out of the predicate or out of an element's destructor
+        // cannot skip the update.
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |cur| {
                     // SAFETY: cur is a live, heap-allocated data node.
                     f((*cur).value().expect("data node has a value"))
                 },
                 |_| {},
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_rank;
+            );
+        }
     }
 
     /// Removes all but the first of consecutive equal elements as determined
@@ -92,6 +99,10 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     /// relative order.
     ///
     /// This operation is `$O(n)$`.
+    ///
+    /// If `same_bucket` or an element's destructor panics, the elements the
+    /// walk had not yet reached are kept in the list, as is the element
+    /// `same_bucket` panicked on; the list stays usable.
     ///
     /// # Examples
     ///
@@ -135,9 +146,14 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
         // raw node pointers, producing non-aliasing exclusive references
         // because each node is a separately heap-allocated Box.  The closure
         // returns before any structural mutation occurs.
-        let (new_rank, new_tail) = unsafe {
+        // `filter_rebuild` publishes the new length and tail itself, so
+        // an unwind out of the predicate or out of an element's destructor
+        // cannot skip the update.
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |cur| {
                     let keep = match prev_kept {
                         None => true,
@@ -155,10 +171,8 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
                     keep
                 },
                 |_| {},
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_rank;
+            );
+        }
     }
 
     /// Removes all but the first of consecutive equal elements.
@@ -171,6 +185,8 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     /// duplicate values from the list.
     ///
     /// This operation is `$O(n)$`.
+    ///
+    /// Panic behaviour matches [`dedup_by`](OrderedSkipList::dedup_by).
     ///
     /// # Examples
     ///
@@ -204,6 +220,8 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     /// elements with a duplicate key.
     ///
     /// This operation is `$O(n)$`.
+    ///
+    /// Panic behaviour matches [`dedup_by`](OrderedSkipList::dedup_by).
     ///
     /// # Examples
     ///
@@ -244,9 +262,12 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use pretty_assertions::assert_eq;
 
     use super::super::OrderedSkipList;
+    use crate::test_util::{PanicOnDrop, bombs};
 
     // MARK: retain
 
@@ -559,5 +580,89 @@ mod tests {
         list.dedup_by_key(|i| *i / 10);
         let got: Vec<i32> = list.iter().copied().collect();
         assert_eq!(got, [10, 20, 30]);
+    }
+
+    // MARK: panic safety
+
+    fn assert_survivors(list: &OrderedSkipList<PanicOnDrop>, expected: &[u32]) {
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, expected);
+        assert_eq!(list.len(), expected.len());
+        assert_eq!(list.first().map(PanicOnDrop::id), expected.first().copied());
+        assert_eq!(list.last().map(PanicOnDrop::id), expected.last().copied());
+        // Indexed lookup goes through the rebuilt skip links, not the `next`
+        // chain the assertions above walk.
+        for (index, id) in expected.iter().enumerate() {
+            assert_eq!(list.get_by_index(index).map(PanicOnDrop::id), Some(*id));
+        }
+        assert!(list.get_by_index(expected.len()).is_none());
+    }
+
+    fn armed_list() -> OrderedSkipList<PanicOnDrop> {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.insert(bomb);
+        }
+        list
+    }
+
+    #[test]
+    fn retain_panicking_drop_keeps_unvisited_elements() {
+        let mut list = armed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.retain(|_| false)));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn dedup_by_panicking_drop_keeps_unvisited_elements() {
+        let mut list = armed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.dedup_by(|_, _| true)));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[0, 8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    /// A list whose elements all destruct cleanly, so the only unwind can come
+    /// from the predicate.
+    fn unarmed_list() -> OrderedSkipList<PanicOnDrop> {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 16) {
+            list.insert(bomb);
+        }
+        list
+    }
+
+    #[test]
+    fn retain_panicking_predicate_keeps_unvisited_elements() {
+        let mut list = unarmed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            list.retain(|element| {
+                assert!(element.id() != 7, "predicate panic");
+                false
+            });
+        }));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn dedup_by_panicking_predicate_keeps_unvisited_elements() {
+        let mut list = unarmed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            list.dedup_by(|later, _earlier| {
+                assert!(later.id() != 7, "predicate panic");
+                true
+            });
+        }));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[0, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     }
 }

--- a/src/ordered_skip_list/iter.rs
+++ b/src/ordered_skip_list/iter.rs
@@ -312,17 +312,17 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
         // OrderedSkipList.  We hold &mut self.  The keep closure returns false
         // for every node, so all nodes are dropped via the on_drop closure that
         // extracts their values.
-        let (new_len, new_tail) = unsafe {
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |_cur| false,
                 |mut boxed| {
                     drained.push(boxed.take_value().expect("data node has a value"));
                 },
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_len;
+            );
+        }
 
         Drain {
             iter: drained.into_iter(),
@@ -427,9 +427,13 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
         // this OrderedSkipList.  We hold &mut self so no other reference to
         // any node exists.  The keep closure reads the value before any
         // structural mutation occurs.
-        let (new_len, new_tail) = unsafe {
+        // `filter_rebuild` publishes the new length and tail itself, so an
+        // unwind out of the comparator cannot skip the update.
+        unsafe {
             Node::filter_rebuild(
                 head,
+                &mut self.len,
+                &mut self.tail,
                 |cur| {
                     if past_hi {
                         return true; // all remaining nodes are past upper bound: keep
@@ -461,10 +465,8 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
                 |mut boxed| {
                     drained.push(boxed.take_value().expect("data node has a value"));
                 },
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_len;
+            );
+        }
 
         Drain {
             iter: drained.into_iter(),
@@ -1022,10 +1024,15 @@ where
         //
         // SAFETY: &'a mut OrderedSkipList is held exclusively.  All raw
         // pointers originate from its heap allocations.
-        let (_, new_tail) = unsafe { Node::filter_rebuild(self.list.head, |_| true, |_| {}) };
-        self.list.tail = new_tail;
-        // self.list.len is already correct: decremented in Iterator::next
-        // once per removed element.
+        unsafe {
+            Node::filter_rebuild(
+                self.list.head,
+                &mut self.list.len,
+                &mut self.list.tail,
+                |_| true,
+                |_| {},
+            );
+        }
     }
 }
 
@@ -1033,12 +1040,17 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::ops::Bound;
+    use core::{cell::Cell, ops::Bound};
+    use std::panic::{AssertUnwindSafe, catch_unwind};
 
     use pretty_assertions::assert_eq;
 
     use super::super::OrderedSkipList;
-    use crate::{comparator::FnComparator, level_generator::geometric::Geometric};
+    use crate::{
+        comparator::FnComparator,
+        level_generator::geometric::Geometric,
+        test_util::{PanicOnDrop, bombs},
+    };
 
     // MARK: iter
 
@@ -1769,5 +1781,106 @@ mod tests {
         let iter = list.extract_if(|_| false);
         // Lower bound is always 0 (predicate outcome unknown).
         assert_eq!(iter.size_hint().0, 0);
+    }
+
+    // MARK: panic safety
+
+    /// A comparator that panics once armed, standing in for any user `Ord` that
+    /// can fail — including `PartialOrdComparator`, which panics by design on
+    /// incomparable values.
+    #[test]
+    fn drain_range_panicking_comparator_keeps_len_consistent() {
+        thread_local! {
+            static ARMED: Cell<bool> = const { Cell::new(false) };
+        }
+
+        let comparator = FnComparator(|a: &u32, b: &u32| {
+            assert!(
+                !(ARMED.with(Cell::get) && (*a == 7 || *b == 7)),
+                "comparator panic"
+            );
+            a.cmp(b)
+        });
+
+        let mut list = OrderedSkipList::<u32, 16, _>::with_comparator(comparator);
+        for i in 0..16_u32 {
+            list.insert(i);
+        }
+
+        ARMED.with(|armed| armed.set(true));
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            drop(list.drain_range(2..));
+        }));
+        ARMED.with(|armed| armed.set(false));
+        assert!(result.is_err());
+
+        // The elements the walk never reached stay in the list, and `len` must
+        // agree with them.
+        let remaining: Vec<u32> = list.iter().copied().collect();
+        assert_eq!(remaining, [0, 1, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), remaining.len());
+        assert_eq!(list.first(), Some(&0));
+        assert_eq!(list.last(), Some(&15));
+        for (index, value) in remaining.iter().enumerate() {
+            assert_eq!(list.get_by_index(index), Some(value));
+        }
+        assert!(list.get_by_index(remaining.len()).is_none());
+    }
+
+    // MARK: extract_if panic safety
+
+    /// Ids 0..=6 are extracted and dropped before the predicate unwinds on
+    /// 7, which is never removed.
+    #[test]
+    fn extract_if_panicking_predicate_keeps_list_consistent() {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 16) {
+            list.insert(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            for extracted in list.extract_if(|element| {
+                assert!(element.id() != 7, "predicate panic");
+                true
+            }) {
+                drop(extracted);
+            }
+        }));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 9);
+        assert_eq!(list.first().map(PanicOnDrop::id), Some(7));
+        assert_eq!(list.last().map(PanicOnDrop::id), Some(15));
+        for (index, id) in ids.iter().enumerate() {
+            assert_eq!(list.get_by_index(index).map(PanicOnDrop::id), Some(*id));
+        }
+    }
+
+    /// Id 7 leaves the list, then unwinds as the loop body drops it.  The
+    /// `ExtractIf` guard still republishes the length and tail.
+    #[test]
+    fn extract_if_panicking_drop_keeps_list_consistent() {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.insert(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            for extracted in list.extract_if(|_| true) {
+                drop(extracted);
+            }
+        }));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 8);
+        assert_eq!(list.first().map(PanicOnDrop::id), Some(8));
+        assert_eq!(list.last().map(PanicOnDrop::id), Some(15));
+        for (index, id) in ids.iter().enumerate() {
+            assert_eq!(list.get_by_index(index).map(PanicOnDrop::id), Some(*id));
+        }
     }
 }

--- a/src/ordered_skip_list/structural.rs
+++ b/src/ordered_skip_list/structural.rs
@@ -21,6 +21,10 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     ///
     /// This operation is `$O(n)$`: all n elements must be dropped.
     ///
+    /// If an element's destructor panics, the remaining elements are kept in
+    /// the list rather than leaked, and the list stays usable; call `clear`
+    /// again to drop them.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -36,22 +40,28 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        let max_levels = self.head_ref().level();
-        // Drop the old sentinel in-place.  `Node::drop` iterates the entire
-        // `next` chain and frees each node one at a time, so this is O(n) and
-        // non-recursive regardless of list length.  Then write a fresh
-        // sentinel into the same allocation.
+        // Detach the chain and reset the bookkeeping before running a single
+        // destructor.  An element `Drop` that unwinds then finds the list
+        // already empty and consistent, rather than leaving `tail` pointing at
+        // a node the unwind has freed.
         //
-        // SAFETY: `self.head` is a live, exclusively-owned allocation;
-        // `drop_in_place` drops the old `Node<T, N>` (and its linked chain),
-        // leaving the memory valid but uninitialized.
-        unsafe { core::ptr::drop_in_place(self.head.as_ptr()) };
-        // SAFETY: The allocation is still live after `drop_in_place`; `write`
-        // initializes it with a fresh sentinel (no destructor runs on the
-        // `write` side).
-        unsafe { self.head.as_ptr().write(Node::new(max_levels)) };
+        // SAFETY: `self.head` is a live, exclusively-owned sentinel, and the
+        // chain hanging off it is owned by this list alone.
+        let chain = unsafe {
+            let head = self.head_mut();
+            for link in head.links_mut() {
+                *link = None;
+            }
+            head.take_next_chain()
+        };
         self.tail = None;
         self.len = 0;
+
+        let head = self.head;
+        // SAFETY: `head` is the exclusively-owned sentinel, its `next` was
+        // emptied above, and `chain` holds the nodes that hung off it, each
+        // allocated by `Box::into_raw` and referenced from nowhere else.
+        unsafe { Node::drop_chain(head, head, &mut self.len, &mut self.tail, chain) };
     }
 
     /// Moves all elements from `other` into `self`, leaving `other` empty.
@@ -146,10 +156,15 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
                 //
                 // SAFETY: self.head is exclusively owned; all reachable nodes
                 // are live heap allocations with no other live references.
-                let (new_len, new_tail) =
-                    unsafe { Node::filter_rebuild(self.head, |_| true, |_| {}) };
-                self.tail = new_tail;
-                self.len = new_len;
+                unsafe {
+                    Node::filter_rebuild(
+                        self.head,
+                        &mut self.len,
+                        &mut self.tail,
+                        |_| true,
+                        |_| {},
+                    );
+                }
             }
         } else {
             // Reverse fast path: every element of other is <= every element of
@@ -210,10 +225,15 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
                     // SAFETY: self.head is exclusively owned; all reachable
                     // nodes are live heap allocations with no other live
                     // references.
-                    let (new_len, new_tail) =
-                        unsafe { Node::filter_rebuild(self.head, |_| true, |_| {}) };
-                    self.tail = new_tail;
-                    self.len = new_len;
+                    unsafe {
+                        Node::filter_rebuild(
+                            self.head,
+                            &mut self.len,
+                            &mut self.tail,
+                            |_| true,
+                            |_| {},
+                        );
+                    }
                 }
             } else {
                 while let Some(v) = other.pop_first() {
@@ -325,16 +345,18 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
         //
         // SAFETY: `self.head` is exclusively owned; every node reachable from
         // it is a live heap allocation with no other live references.
-        let (self_len, self_tail) = unsafe { Node::filter_rebuild(self.head, |_| true, |_| {}) };
+        unsafe { Node::filter_rebuild(self.head, &mut self.len, &mut self.tail, |_| true, |_| {}) };
         // SAFETY: `result.head` is exclusively owned; every node reachable
         // from it is a live heap allocation with no other live references.
-        let (result_len, result_tail) =
-            unsafe { Node::filter_rebuild(result.head, |_| true, |_| {}) };
-
-        self.tail = self_tail;
-        self.len = self_len;
-        result.tail = result_tail;
-        result.len = result_len;
+        unsafe {
+            Node::filter_rebuild(
+                result.head,
+                &mut result.len,
+                &mut result.tail,
+                |_| true,
+                |_| {},
+            );
+        }
 
         result
     }
@@ -439,7 +461,13 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
             // Rebuild result's skip links.
             // SAFETY: result.head is exclusively owned; all reachable nodes are live.
             unsafe {
-                result.tail = Node::rebuild(result.head);
+                Node::filter_rebuild(
+                    result.head,
+                    &mut result.len,
+                    &mut result.tail,
+                    |_| true,
+                    |_| {},
+                );
             }
 
             return result;
@@ -483,10 +511,14 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
             };
             (*result.head.as_ptr()).set_head_next(first_of_tail);
 
-            self.len = at;
-
-            self.tail = Node::rebuild(self.head);
-            result.tail = Node::rebuild(result.head);
+            Node::filter_rebuild(self.head, &mut self.len, &mut self.tail, |_| true, |_| {});
+            Node::filter_rebuild(
+                result.head,
+                &mut result.len,
+                &mut result.tail,
+                |_| true,
+                |_| {},
+            );
 
             result
         }
@@ -499,6 +531,10 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     ///
     /// This operation is `$O(\log n + k)$` where k is the number of elements
     /// removed.
+    ///
+    /// If an element's destructor panics, the elements it had not yet reached
+    /// are kept in the list rather than leaked, so the list may still be
+    /// longer than `len`.
     ///
     /// # Examples
     ///
@@ -525,8 +561,9 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
     )]
     #[expect(
         clippy::multiple_unsafe_ops_per_block,
-        reason = "link clearing and truncate_next touch provably disjoint heap nodes; \
-                  splitting across blocks would require unsafe-crossing raw-pointer variables"
+        reason = "link clearing, detaching the suffix and freeing it touch provably \
+                  disjoint heap nodes; splitting across blocks would require \
+                  unsafe-crossing raw-pointer variables"
     )]
     #[inline]
     pub fn truncate(&mut self, len: usize) {
@@ -542,6 +579,7 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
 
         // IndexMutVisitor with target = len stops when current = the node at
         // rank len (the new tail).  into_parts() returns that node as `current`.
+        let head = self.head;
         let (new_tail_node, precursors, _) = {
             let mut visitor = IndexMutVisitor::new(self.head, len);
             visitor.traverse();
@@ -552,7 +590,7 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
         // traversal.  They originate from heap allocations owned by this
         // OrderedSkipList.  No safe references to any node exist while this block
         // runs.
-        let new_tail_ptr: *mut Node<T, N> = unsafe {
+        unsafe {
             let new_tail_ptr: *mut Node<T, N> = new_tail_node.as_ptr();
 
             let new_tail_height = (*new_tail_ptr).level();
@@ -570,24 +608,32 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> OrderedSkipList<T, 
                 (*precursors[l].as_ptr()).links_mut()[l] = None;
             }
 
-            (*new_tail_ptr).truncate_next();
+            // Commit the new tail and length before any element is freed:
+            // freeing runs element destructors, and one that unwinds must not
+            // leave `tail` pointing into the region it has freed.
+            self.tail = Some(new_tail_node);
+            self.len = len;
 
-            new_tail_ptr
-        };
-
-        // SAFETY: new_tail_ptr is a live, heap-allocated node owned by this
-        // OrderedSkipList; it will not be freed until the list itself is dropped.
-        self.tail = Some(unsafe { NonNull::new_unchecked(new_tail_ptr) });
-        self.len = len;
+            // Detach the removed suffix, then free it.  An element destructor
+            // that unwinds leaves the rest of the suffix re-attached after the
+            // new tail rather than leaked.
+            let suffix = (*new_tail_ptr).take_next_chain();
+            Node::drop_chain(head, new_tail_node, &mut self.len, &mut self.tail, suffix);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use pretty_assertions::assert_eq;
 
     use super::super::OrderedSkipList;
-    use crate::comparator::FnComparator;
+    use crate::{
+        comparator::FnComparator,
+        test_util::{PanicOnDrop, bombs},
+    };
 
     // MARK: clear
 
@@ -1448,5 +1494,89 @@ mod tests {
             right.iter().map(String::as_str).collect::<Vec<_>>(),
             ["cherry", "date"]
         );
+    }
+
+    // MARK: panic safety
+
+    #[test]
+    fn clear_panicking_drop_leaves_list_empty() {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 15) {
+            list.insert(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.clear()));
+        assert!(result.is_err());
+
+        assert_eq!(list.len(), 0);
+        assert!(list.is_empty());
+        assert!(list.first().is_none());
+        assert!(list.last().is_none());
+        assert_eq!(list.iter().count(), 0);
+
+        list.insert(PanicOnDrop::new(100));
+        assert_eq!(list.last().map(PanicOnDrop::id), Some(100));
+    }
+
+    #[test]
+    fn truncate_panicking_drop_leaves_list_truncated() {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 15) {
+            list.insert(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.truncate(4)));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [0, 1, 2, 3]);
+        assert_eq!(list.len(), 4);
+        assert_eq!(list.first().map(PanicOnDrop::id), Some(0));
+        assert_eq!(list.last().map(PanicOnDrop::id), Some(3));
+        assert!(list.get_by_index(4).is_none());
+
+        list.insert(PanicOnDrop::new(100));
+        assert_eq!(list.last().map(PanicOnDrop::id), Some(100));
+    }
+
+    /// The elements a panicking `clear` never reached stay in the list; they
+    /// must not be leaked, and a second `clear` must drop them.
+    #[test]
+    fn clear_panicking_drop_keeps_unreached_elements() {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.insert(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.clear()));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 8);
+        assert_eq!(list.first().map(PanicOnDrop::id), Some(8));
+        assert_eq!(list.last().map(PanicOnDrop::id), Some(15));
+
+        list.clear();
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn truncate_panicking_drop_keeps_unreached_elements() {
+        let mut list = OrderedSkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.insert(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.truncate(4)));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [0, 1, 2, 3, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 12);
+        assert_eq!(list.last().map(PanicOnDrop::id), Some(15));
+        for (index, id) in ids.iter().enumerate() {
+            assert_eq!(list.get_by_index(index).map(PanicOnDrop::id), Some(*id));
+        }
     }
 }

--- a/src/ordered_skip_list/traits.rs
+++ b/src/ordered_skip_list/traits.rs
@@ -105,7 +105,7 @@ impl<T: Clone, C: Comparator<T> + Clone, G: LevelGenerator + Clone, const N: usi
         // SAFETY: self.head is a valid, live head sentinel.  Every src_nn is a
         // live data node owned by self.  new_head / prev_nn are exclusively
         // owned by new_list and have no other live references.
-        let tail = unsafe {
+        unsafe {
             let mut prev_nn = new_head;
             let mut src_opt = self.head.as_ref().next();
 
@@ -119,9 +119,14 @@ impl<T: Clone, C: Comparator<T> + Clone, G: LevelGenerator + Clone, const N: usi
                 src_opt = src_node.next();
             }
 
-            Node::rebuild(new_head)
-        };
-        new_list.tail = tail;
+            Node::filter_rebuild(
+                new_head,
+                &mut new_list.len,
+                &mut new_list.tail,
+                |_| true,
+                |_| {},
+            );
+        }
 
         new_list
     }

--- a/src/skip_list/filter.rs
+++ b/src/skip_list/filter.rs
@@ -16,6 +16,10 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     ///
     /// This operation is `$O(n)$`.
     ///
+    /// If `same_bucket` or an element's destructor panics, the elements the
+    /// walk had not yet reached are kept in the list, as is the element
+    /// `same_bucket` panicked on; the list stays usable.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -58,9 +62,14 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
         // pointers, producing non-aliasing exclusive references because each
         // node is a separately heap-allocated Box.  The closure returns before
         // any structural mutation occurs.
-        let (new_rank, new_tail) = unsafe {
+        // `filter_rebuild` publishes the new length and tail itself, so
+        // an unwind out of the predicate or out of an element's destructor
+        // cannot skip the update.
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |cur| {
                     let keep = match prev_kept {
                         None => true,
@@ -78,10 +87,8 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
                     keep
                 },
                 |_| {},
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_rank;
+            );
+        }
     }
 
     /// Removes all but the first of consecutive equal elements.
@@ -90,6 +97,8 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     /// compares elements using [`PartialEq`].
     ///
     /// This operation is `$O(n)$`.
+    ///
+    /// Panic behaviour matches [`dedup_by`](SkipList::dedup_by).
     ///
     /// # Examples
     ///
@@ -119,6 +128,8 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     /// compares the keys derived from each element.
     ///
     /// This operation is `$O(n)$`.
+    ///
+    /// Panic behaviour matches [`dedup_by`](SkipList::dedup_by).
     ///
     /// # Examples
     ///
@@ -164,6 +175,10 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     ///
     /// This operation is `$O(n)$`.
     ///
+    /// If `f` or an element's destructor panics, the elements the walk had
+    /// not yet reached are kept in the list, as is the element `f` panicked
+    /// on; the list stays usable.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -201,18 +216,21 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
         // this SkipList.  We hold &mut self so no other reference to any node
         // exists.  The closure reads the value and returns before any
         // structural mutation occurs.
-        let (new_rank, new_tail) = unsafe {
+        // `filter_rebuild` publishes the new length and tail itself, so
+        // an unwind out of the predicate or out of an element's destructor
+        // cannot skip the update.
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |cur| {
                     // SAFETY: cur is a live, heap-allocated data node.
                     f((*cur).value().expect("data node has a value"))
                 },
                 |_| {},
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_rank;
+            );
+        }
     }
 
     /// Retains only the elements specified by the predicate, passing a mutable
@@ -223,6 +241,10 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     /// retained elements before it returns `true`.
     ///
     /// This operation is `$O(n)$`.
+    ///
+    /// If `f` or an element's destructor panics, the elements the walk had
+    /// not yet reached are kept in the list, as is the element `f` panicked
+    /// on; the list stays usable.
     ///
     /// # Examples
     ///
@@ -268,26 +290,32 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
         // this SkipList.  We hold &mut self so no other reference to any node
         // exists.  The &mut T borrow created by `value_mut()` expires before
         // `filter_rebuild` performs any structural mutation on the node.
-        let (new_rank, new_tail) = unsafe {
+        // `filter_rebuild` publishes the new length and tail itself, so
+        // an unwind out of the predicate or out of an element's destructor
+        // cannot skip the update.
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |cur| {
                     // SAFETY: cur is a live, heap-allocated data node.
                     f((*cur).value_mut().expect("data node has a value"))
                 },
                 |_| {},
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_rank;
+            );
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use pretty_assertions::assert_eq;
 
     use super::super::SkipList;
+    use crate::test_util::{PanicOnDrop, bombs};
 
     // MARK: retain
 
@@ -649,5 +677,120 @@ mod tests {
         list.dedup_by_key(|i| *i / 10);
         let got: Vec<i32> = list.iter().copied().collect();
         assert_eq!(got, [10, 20, 30]);
+    }
+
+    // MARK: panic safety
+
+    /// Elements the walk has not yet reached must survive an unwind, in order,
+    /// reachable through both the `next` chain and the rebuilt skip links.
+    fn assert_survivors(list: &SkipList<PanicOnDrop>, expected: &[u32]) {
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, expected);
+        assert_eq!(list.len(), expected.len());
+        assert_eq!(list.front().map(PanicOnDrop::id), expected.first().copied());
+        assert_eq!(list.back().map(PanicOnDrop::id), expected.last().copied());
+        for (index, id) in expected.iter().enumerate() {
+            assert_eq!(list.get(index).map(PanicOnDrop::id), Some(*id));
+        }
+        assert!(list.get(expected.len()).is_none());
+    }
+
+    fn armed_list() -> SkipList<PanicOnDrop> {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.push_back(bomb);
+        }
+        list
+    }
+
+    #[test]
+    fn retain_panicking_drop_keeps_unvisited_elements() {
+        let mut list = armed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.retain(|_| false)));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn retain_mut_panicking_drop_keeps_unvisited_elements() {
+        let mut list = armed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            list.retain_mut(|_: &mut PanicOnDrop| false);
+        }));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn dedup_by_panicking_drop_keeps_unvisited_elements() {
+        let mut list = armed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.dedup_by(|_, _| true)));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[0, 8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn retain_panicking_predicate_keeps_unvisited_elements() {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 16) {
+            list.push_back(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            list.retain(|element| {
+                assert!(element.id() != 7, "predicate panic");
+                false
+            });
+        }));
+        assert!(result.is_err());
+
+        // The element the predicate panicked on is still owned by the list.
+        assert_survivors(&list, &[7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    /// A list whose elements all destruct cleanly, so the only unwind can come
+    /// from the predicate.
+    fn unarmed_list() -> SkipList<PanicOnDrop> {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 16) {
+            list.push_back(bomb);
+        }
+        list
+    }
+
+    #[test]
+    fn retain_mut_panicking_predicate_keeps_unvisited_elements() {
+        let mut list = unarmed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            list.retain_mut(|element: &mut PanicOnDrop| {
+                assert!(element.id() != 7, "predicate panic");
+                false
+            });
+        }));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn dedup_by_panicking_predicate_keeps_unvisited_elements() {
+        let mut list = unarmed_list();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            list.dedup_by(|later, _earlier| {
+                assert!(later.id() != 7, "predicate panic");
+                true
+            });
+        }));
+        assert!(result.is_err());
+
+        assert_survivors(&list, &[0, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     }
 }

--- a/src/skip_list/iter.rs
+++ b/src/skip_list/iter.rs
@@ -310,9 +310,11 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
         // SkipList.  We hold &mut self.  The keep closure does not structurally
         // modify the chain; the on_drop closure pops the node and extracts the
         // value before the box is dropped.
-        let (new_rank, new_tail) = unsafe {
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |_cur| {
                     let in_range = current_index >= start && current_index < end;
                     current_index = current_index.saturating_add(1);
@@ -321,10 +323,8 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
                 |mut boxed| {
                     drained.push(boxed.take_value().expect("data node has a value"));
                 },
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_rank;
+            );
+        }
 
         Drain {
             iter: drained.into_iter(),
@@ -995,18 +995,26 @@ where
         //
         // SAFETY: &'a mut SkipList is held exclusively.  All raw pointers
         // originate from its heap allocations.
-        let (_, new_tail) = unsafe { Node::filter_rebuild(self.list.head, |_| true, |_| {}) };
-        self.list.tail = new_tail;
-        // self.list.len is already correct: decremented in Iterator::next
-        // once per removed element.
+        unsafe {
+            Node::filter_rebuild(
+                self.list.head,
+                &mut self.list.len,
+                &mut self.list.tail,
+                |_| true,
+                |_| {},
+            );
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use pretty_assertions::assert_eq;
 
     use super::super::SkipList;
+    use crate::test_util::{PanicOnDrop, bombs};
 
     // MARK: iter
 
@@ -2077,5 +2085,62 @@ mod tests {
             list.push_back(i);
         }
         drop(list.range(0..10));
+    }
+
+    // MARK: extract_if panic safety
+
+    /// Ids 0..=6 are extracted and dropped before the predicate unwinds on
+    /// 7, which is never removed.
+    #[test]
+    fn extract_if_panicking_predicate_keeps_list_consistent() {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 16) {
+            list.push_back(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            for extracted in list.extract_if(|element| {
+                assert!(element.id() != 7, "predicate panic");
+                true
+            }) {
+                drop(extracted);
+            }
+        }));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 9);
+        assert_eq!(list.front().map(PanicOnDrop::id), Some(7));
+        assert_eq!(list.back().map(PanicOnDrop::id), Some(15));
+        for (index, id) in ids.iter().enumerate() {
+            assert_eq!(list.get(index).map(PanicOnDrop::id), Some(*id));
+        }
+    }
+
+    /// Id 7 leaves the list, then unwinds as the loop body drops it.  The
+    /// `ExtractIf` guard still republishes the length and tail.
+    #[test]
+    fn extract_if_panicking_drop_keeps_list_consistent() {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.push_back(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            for extracted in list.extract_if(|_| true) {
+                drop(extracted);
+            }
+        }));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 8);
+        assert_eq!(list.front().map(PanicOnDrop::id), Some(8));
+        assert_eq!(list.back().map(PanicOnDrop::id), Some(15));
+        for (index, id) in ids.iter().enumerate() {
+            assert_eq!(list.get(index).map(PanicOnDrop::id), Some(*id));
+        }
     }
 }

--- a/src/skip_list/structural.rs
+++ b/src/skip_list/structural.rs
@@ -21,6 +21,10 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     ///
     /// This operation is `$O(n)$`: all n elements must be dropped.
     ///
+    /// If an element's destructor panics, the remaining elements are kept in
+    /// the list rather than leaked, and the list stays usable; call `clear`
+    /// again to drop them.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -36,22 +40,28 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        let max_levels = self.head_ref().level();
-        // Drop the old sentinel in-place.  `Node::drop` iterates the entire
-        // `next` chain and frees each node one at a time, so this is O(n) and
-        // non-recursive regardless of list length.  Then write a fresh
-        // sentinel into the same allocation.
+        // Detach the chain and reset the bookkeeping before running a single
+        // destructor.  An element `Drop` that unwinds then finds the list
+        // already empty and consistent, rather than leaving `tail` pointing at
+        // a node the unwind has freed.
         //
-        // SAFETY: `self.head` is a live, exclusively-owned allocation;
-        // `drop_in_place` drops the old `Node<T, N>` (and its linked chain),
-        // leaving the memory valid but uninitialized.
-        unsafe { core::ptr::drop_in_place(self.head.as_ptr()) };
-        // SAFETY: The allocation is still live after `drop_in_place`; `write`
-        // initializes it with a fresh sentinel; no destructor runs on the
-        // `write` side.
-        unsafe { self.head.as_ptr().write(Node::new(max_levels)) };
+        // SAFETY: `self.head` is a live, exclusively-owned sentinel, and the
+        // chain hanging off it is owned by this list alone.
+        let chain = unsafe {
+            let head = self.head_mut();
+            for link in head.links_mut() {
+                *link = None;
+            }
+            head.take_next_chain()
+        };
         self.tail = None;
         self.len = 0;
+
+        let head = self.head;
+        // SAFETY: `head` is the exclusively-owned sentinel, its `next` was
+        // emptied above, and `chain` holds the nodes that hung off it, each
+        // allocated by `Box::into_raw` and referenced from nowhere else.
+        unsafe { Node::drop_chain(head, head, &mut self.len, &mut self.tail, chain) };
     }
 
     /// Shortens the list, keeping only the first `len` elements and dropping
@@ -62,6 +72,10 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     /// This operation is `$O(\log n + k)$` where k = `self.len() - len` is the
     /// number of elements removed: `$O(\log n)$` to locate the new tail and update
     /// the skip links, then `$O(k)$` to drop k values.
+    ///
+    /// If an element's destructor panics, the elements it had not yet reached
+    /// are kept in the list rather than leaked, so the list may still be
+    /// longer than `len`.
     ///
     /// # Examples
     ///
@@ -88,8 +102,9 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
     )]
     #[expect(
         clippy::multiple_unsafe_ops_per_block,
-        reason = "link clearing and truncate_next touch provably disjoint heap nodes; \
-                  splitting across blocks would require unsafe-crossing raw-pointer variables"
+        reason = "link clearing, detaching the suffix and freeing it touch provably \
+                  disjoint heap nodes; splitting across blocks would require \
+                  unsafe-crossing raw-pointer variables"
     )]
     #[inline]
     pub fn truncate(&mut self, len: usize) {
@@ -107,6 +122,7 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
         // IndexMutVisitor with target = len advances directly to the node at rank len.
         // `current` from into_parts() is the new tail node itself.
         // into_parts() releases the &mut borrow.
+        let head = self.head;
         let (new_tail_node, precursors, _) = {
             let mut visitor = IndexMutVisitor::new(self.head, len);
             visitor.traverse();
@@ -116,7 +132,7 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
         // SAFETY: All raw pointers come from NonNull<Node<T, N>> captured during
         // traversal.  They originate from heap allocations owned by this SkipList.
         // No safe references to any node exist while this block runs.
-        let new_tail_ptr: *mut Node<T, N> = unsafe {
+        unsafe {
             // `current` is the node at rank len (the new tail).
             let new_tail_ptr: *mut Node<T, N> = new_tail_node.as_ptr();
 
@@ -135,15 +151,18 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
                 (*precursors[l].as_ptr()).links_mut()[l] = None;
             }
 
-            (*new_tail_ptr).truncate_next();
+            // Commit the new tail and length before any element is freed:
+            // freeing runs element destructors, and one that unwinds must not
+            // leave `tail` pointing into the region it has freed.
+            self.tail = Some(new_tail_node);
+            self.len = len;
 
-            new_tail_ptr
-        };
-
-        // SAFETY: new_tail_ptr is a live, heap-allocated node owned by this
-        // SkipList; it will not be freed until the list itself is dropped.
-        self.tail = Some(unsafe { NonNull::new_unchecked(new_tail_ptr) });
-        self.len = len;
+            // Detach the removed suffix, then free it.  An element destructor
+            // that unwinds leaves the rest of the suffix re-attached after the
+            // new tail rather than leaked.
+            let suffix = (*new_tail_ptr).take_next_chain();
+            Node::drop_chain(head, new_tail_node, &mut self.len, &mut self.tail, suffix);
+        }
     }
 
     /// Splits the list at the given index, returning a new list containing
@@ -252,7 +271,13 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
             // SAFETY: result.head is exclusively owned; all nodes reachable
             // via result.head.next are live heap allocations.
             unsafe {
-                result.tail = Node::rebuild(result.head);
+                Node::filter_rebuild(
+                    result.head,
+                    &mut result.len,
+                    &mut result.tail,
+                    |_| true,
+                    |_| {},
+                );
             }
 
             return result;
@@ -289,11 +314,14 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
             };
             (*result.head.as_ptr()).set_head_next(first_of_tail);
 
-            self.tail = Some(NonNull::new_unchecked(pivot));
-            self.len = at;
-
-            self.tail = Node::rebuild(self.head);
-            result.tail = Node::rebuild(result.head);
+            Node::filter_rebuild(self.head, &mut self.len, &mut self.tail, |_| true, |_| {});
+            Node::filter_rebuild(
+                result.head,
+                &mut result.len,
+                &mut result.tail,
+                |_| true,
+                |_| {},
+            );
 
             result
         }
@@ -436,9 +464,12 @@ impl<T, G: LevelGenerator, const N: usize> SkipList<T, N, G> {
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use pretty_assertions::assert_eq;
 
     use super::super::SkipList;
+    use crate::test_util::{PanicOnDrop, bombs};
 
     // MARK: clear
 
@@ -1006,5 +1037,92 @@ mod tests {
             ");
         }
         Ok(())
+    }
+
+    // MARK: panic safety
+
+    #[test]
+    fn clear_panicking_drop_leaves_list_empty() {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 15) {
+            list.push_back(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.clear()));
+        assert!(result.is_err());
+
+        assert_eq!(list.len(), 0);
+        assert!(list.is_empty());
+        assert!(list.front().is_none());
+        assert!(list.back().is_none());
+        assert_eq!(list.iter().count(), 0);
+
+        list.push_back(PanicOnDrop::new(100));
+        assert_eq!(list.back().map(PanicOnDrop::id), Some(100));
+    }
+
+    #[test]
+    fn truncate_panicking_drop_leaves_list_truncated() {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 15) {
+            list.push_back(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.truncate(4)));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [0, 1, 2, 3]);
+        assert_eq!(list.len(), 4);
+        assert_eq!(list.front().map(PanicOnDrop::id), Some(0));
+        assert_eq!(list.back().map(PanicOnDrop::id), Some(3));
+        assert!(list.get(4).is_none());
+
+        list.push_back(PanicOnDrop::new(100));
+        assert_eq!(list.back().map(PanicOnDrop::id), Some(100));
+    }
+
+    /// The elements a panicking `clear` never reached stay in the list; they
+    /// must not be leaked, and a second `clear` must drop them.
+    #[test]
+    fn clear_panicking_drop_keeps_unreached_elements() {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.push_back(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.clear()));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 8);
+        assert_eq!(list.front().map(PanicOnDrop::id), Some(8));
+        assert_eq!(list.back().map(PanicOnDrop::id), Some(15));
+        for (index, id) in ids.iter().enumerate() {
+            assert_eq!(list.get(index).map(PanicOnDrop::id), Some(*id));
+        }
+
+        list.clear();
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn truncate_panicking_drop_keeps_unreached_elements() {
+        let mut list = SkipList::<PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            list.push_back(bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| list.truncate(4)));
+        assert!(result.is_err());
+
+        let ids: Vec<u32> = list.iter().map(PanicOnDrop::id).collect();
+        assert_eq!(ids, [0, 1, 2, 3, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(list.len(), 12);
+        assert_eq!(list.back().map(PanicOnDrop::id), Some(15));
+        for (index, id) in ids.iter().enumerate() {
+            assert_eq!(list.get(index).map(PanicOnDrop::id), Some(*id));
+        }
     }
 }

--- a/src/skip_map/filter.rs
+++ b/src/skip_map/filter.rs
@@ -13,6 +13,10 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
     ///
     /// This operation runs in `$O(n)$` time: every pair is visited exactly once.
     ///
+    /// If `f` or an entry's destructor panics, the entries the walk had not
+    /// yet reached are kept in the map, as is the entry `f` panicked on; the
+    /// map stays usable.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -55,9 +59,14 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
         // this SkipMap.  We hold &mut self so no other reference to any node
         // exists.  The closure reads/mutates the value and returns before any
         // structural mutation occurs.
-        let (new_rank, new_tail) = unsafe {
+        // `filter_rebuild` publishes the new length and tail itself, so
+        // an unwind out of the predicate or out of an element's destructor
+        // cannot skip the update.
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |cur| {
                     // SAFETY: cur is a live, heap-allocated data node; no
                     // other reference to this node exists within the closure.
@@ -65,18 +74,19 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
                     f(k, v)
                 },
                 |_| {},
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_rank;
+            );
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use pretty_assertions::assert_eq;
 
     use super::super::SkipMap;
+    use crate::test_util::{PanicOnDrop, bombs};
 
     // MARK: retain
 
@@ -232,5 +242,53 @@ mod tests {
         map.retain(|k, _| *k > 2);
         let got: Vec<i32> = map.keys().copied().collect();
         assert_eq!(got, [4, 6, 8]);
+    }
+
+    // MARK: panic safety
+
+    #[test]
+    fn retain_panicking_drop_keeps_unvisited_entries() {
+        let mut map = SkipMap::<u32, PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            map.insert(bomb.id(), bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| map.retain(|_, _| false)));
+        assert!(result.is_err());
+
+        let expected = [8, 9, 10, 11, 12, 13, 14, 15];
+        let keys: Vec<u32> = map.keys().copied().collect();
+        assert_eq!(keys, expected);
+        assert_eq!(map.len(), expected.len());
+        assert_eq!(map.first_key_value().map(|(k, _)| *k), Some(8));
+        assert_eq!(map.last_key_value().map(|(k, _)| *k), Some(15));
+        for key in expected {
+            assert_eq!(map.get(&key).map(PanicOnDrop::id), Some(key));
+        }
+    }
+
+    #[test]
+    fn retain_panicking_predicate_keeps_unvisited_entries() {
+        let mut map = SkipMap::<u32, PanicOnDrop>::new();
+        for bomb in bombs(16, 16) {
+            map.insert(bomb.id(), bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            map.retain(|key, _value| {
+                assert!(*key != 7, "predicate panic");
+                false
+            });
+        }));
+        assert!(result.is_err());
+
+        let expected = [7, 8, 9, 10, 11, 12, 13, 14, 15];
+        let keys: Vec<u32> = map.keys().copied().collect();
+        assert_eq!(keys, expected);
+        assert_eq!(map.len(), expected.len());
+        assert_eq!(map.last_key_value().map(|(k, _)| *k), Some(15));
+        for key in expected {
+            assert_eq!(map.get(&key).map(PanicOnDrop::id), Some(key));
+        }
     }
 }

--- a/src/skip_map/iter.rs
+++ b/src/skip_map/iter.rs
@@ -536,17 +536,17 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
         // SAFETY: All raw pointers come from heap allocations owned by this
         // SkipMap.  We hold &mut self.  The keep closure returns false for every
         // node, so all nodes are dropped via the on_drop closure.
-        let (new_len, new_tail) = unsafe {
+        unsafe {
             Node::filter_rebuild(
                 self.head,
+                &mut self.len,
+                &mut self.tail,
                 |_cur| false,
                 |mut boxed| {
                     drained.push(boxed.take_value().expect("data node has a value"));
                 },
-            )
-        };
-        self.tail = new_tail;
-        self.len = new_len;
+            );
+        }
 
         Drain {
             iter: drained.into_iter(),
@@ -1655,10 +1655,15 @@ where
         //
         // SAFETY: &'a mut SkipMap is held exclusively.  All raw pointers
         // originate from its heap allocations.
-        let (_, new_tail) = unsafe { Node::filter_rebuild(self.list.head, |_| true, |_| {}) };
-        self.list.tail = new_tail;
-        // self.list.len is already correct: decremented in Iterator::next
-        // once per removed entry.
+        unsafe {
+            Node::filter_rebuild(
+                self.list.head,
+                &mut self.list.len,
+                &mut self.list.tail,
+                |_| true,
+                |_| {},
+            );
+        }
     }
 }
 
@@ -1667,11 +1672,15 @@ where
 #[cfg(test)]
 mod tests {
     use core::ops::Bound;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
 
     use pretty_assertions::assert_eq;
 
     use super::super::SkipMap;
-    use crate::comparator::FnComparator;
+    use crate::{
+        comparator::FnComparator,
+        test_util::{PanicOnDrop, bombs},
+    };
 
     fn map_from<const N: usize>(pairs: [(&'static str, i32); N]) -> SkipMap<&'static str, i32> {
         let mut m = SkipMap::new();
@@ -2224,5 +2233,62 @@ mod tests {
         assert_eq!(extracted, [(3, 30), (1, 10)]);
         let remaining: Vec<_> = map.iter().map(|(&k, &v)| (k, v)).collect();
         assert_eq!(remaining, [(2, 20)]);
+    }
+
+    // MARK: extract_if panic safety
+
+    /// Keys 0..=6 are extracted and dropped before the predicate unwinds on
+    /// 7, whose entry is never removed.
+    #[test]
+    fn extract_if_panicking_predicate_keeps_map_consistent() {
+        let mut map = SkipMap::<u32, PanicOnDrop>::new();
+        for bomb in bombs(16, 16) {
+            map.insert(bomb.id(), bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            for extracted in map.extract_if(|key, _value| {
+                assert!(*key != 7, "predicate panic");
+                true
+            }) {
+                drop(extracted);
+            }
+        }));
+        assert!(result.is_err());
+
+        let keys: Vec<u32> = map.iter().map(|(&key, _)| key).collect();
+        assert_eq!(keys, [7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(map.len(), 9);
+        assert_eq!(map.first_key_value().map(|(&key, _)| key), Some(7));
+        assert_eq!(map.last_key_value().map(|(&key, _)| key), Some(15));
+        for key in &keys {
+            assert_eq!(map.get(key).map(PanicOnDrop::id), Some(*key));
+        }
+    }
+
+    /// Key 7's value leaves the map, then unwinds as the loop body drops
+    /// it.  The `ExtractIf` guard still republishes the length and tail.
+    #[test]
+    fn extract_if_panicking_drop_keeps_map_consistent() {
+        let mut map = SkipMap::<u32, PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            map.insert(bomb.id(), bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            for extracted in map.extract_if(|_, _| true) {
+                drop(extracted);
+            }
+        }));
+        assert!(result.is_err());
+
+        let keys: Vec<u32> = map.iter().map(|(&key, _)| key).collect();
+        assert_eq!(keys, [8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(map.len(), 8);
+        assert_eq!(map.first_key_value().map(|(&key, _)| key), Some(8));
+        assert_eq!(map.last_key_value().map(|(&key, _)| key), Some(15));
+        for key in &keys {
+            assert_eq!(map.get(key).map(PanicOnDrop::id), Some(*key));
+        }
     }
 }

--- a/src/skip_map/structural.rs
+++ b/src/skip_map/structural.rs
@@ -21,6 +21,10 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
     ///
     /// This operation is `$O(n)$`: all n entries must be dropped.
     ///
+    /// If an entry's destructor panics, the remaining entries are kept in the
+    /// map rather than leaked, and the map stays usable; call `clear` again to
+    /// drop them.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -35,22 +39,28 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        let max_levels = self.head_ref().level();
-        // Drop the old sentinel in-place.  `Node::drop` iterates the entire
-        // `next` chain and frees each node one at a time, so this is O(n) and
-        // non-recursive regardless of map size.  Then write a fresh sentinel
-        // into the same allocation.
+        // Detach the chain and reset the bookkeeping before running a single
+        // destructor.  An entry `Drop` that unwinds then finds the map already
+        // empty and consistent, rather than leaving `tail` pointing at a node
+        // the unwind has freed.
         //
-        // SAFETY: `self.head` is a live, exclusively-owned allocation;
-        // `drop_in_place` drops the old `Node<(K,V), N>` (and its linked chain),
-        // leaving the memory valid but uninitialized.
-        unsafe { core::ptr::drop_in_place(self.head.as_ptr()) };
-        // SAFETY: The allocation is still live after `drop_in_place`; `write`
-        // initializes it with a fresh sentinel, and no destructor runs on the
-        // `write` side.
-        unsafe { self.head.as_ptr().write(Node::new(max_levels)) };
+        // SAFETY: `self.head` is a live, exclusively-owned sentinel, and the
+        // chain hanging off it is owned by this map alone.
+        let chain = unsafe {
+            let head = self.head_mut();
+            for link in head.links_mut() {
+                *link = None;
+            }
+            head.take_next_chain()
+        };
         self.tail = None;
         self.len = 0;
+
+        let head = self.head;
+        // SAFETY: `head` is the exclusively-owned sentinel, its `next` was
+        // emptied above, and `chain` holds the nodes that hung off it, each
+        // allocated by `Box::into_raw` and referenced from nowhere else.
+        unsafe { Node::drop_chain(head, head, &mut self.len, &mut self.tail, chain) };
     }
 
     /// Moves all entries from `other` into `self`, leaving `other` empty.
@@ -152,10 +162,15 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
                 //
                 // SAFETY: self.head is exclusively owned; all reachable nodes
                 // are live heap allocations with no other live references.
-                let (new_len, new_tail) =
-                    unsafe { Node::filter_rebuild(self.head, |_| true, |_| {}) };
-                self.tail = new_tail;
-                self.len = new_len;
+                unsafe {
+                    Node::filter_rebuild(
+                        self.head,
+                        &mut self.len,
+                        &mut self.tail,
+                        |_| true,
+                        |_| {},
+                    );
+                }
             }
         } else {
             // Reverse fast path: every key of other is strictly less than every
@@ -222,10 +237,15 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
                     // SAFETY: self.head is exclusively owned; all reachable
                     // nodes are live heap allocations with no other live
                     // references.
-                    let (new_len, new_tail) =
-                        unsafe { Node::filter_rebuild(self.head, |_| true, |_| {}) };
-                    self.tail = new_tail;
-                    self.len = new_len;
+                    unsafe {
+                        Node::filter_rebuild(
+                            self.head,
+                            &mut self.len,
+                            &mut self.tail,
+                            |_| true,
+                            |_| {},
+                        );
+                    }
                 }
             } else {
                 // Slow path: overlapping key ranges, insert each entry individually.
@@ -335,16 +355,18 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
         //
         // SAFETY: `self.head` is exclusively owned; every node reachable from
         // it is a live heap allocation with no other live references.
-        let (self_len, self_tail) = unsafe { Node::filter_rebuild(self.head, |_| true, |_| {}) };
+        unsafe { Node::filter_rebuild(self.head, &mut self.len, &mut self.tail, |_| true, |_| {}) };
         // SAFETY: `result.head` is exclusively owned; every node reachable
         // from it is a live heap allocation with no other live references.
-        let (result_len, result_tail) =
-            unsafe { Node::filter_rebuild(result.head, |_| true, |_| {}) };
-
-        self.tail = self_tail;
-        self.len = self_len;
-        result.tail = result_tail;
-        result.len = result_len;
+        unsafe {
+            Node::filter_rebuild(
+                result.head,
+                &mut result.len,
+                &mut result.tail,
+                |_| true,
+                |_| {},
+            );
+        }
 
         result
     }
@@ -403,9 +425,12 @@ impl<K, V, const N: usize, C: Comparator<K>, G: LevelGenerator> SkipMap<K, V, N,
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use pretty_assertions::assert_eq;
 
     use super::super::SkipMap;
+    use crate::test_util::{PanicOnDrop, bombs};
 
     // MARK: clear
 
@@ -895,5 +920,52 @@ mod tests {
                 .collect::<Vec<_>>(),
             [("cherry", 3), ("date", 4)]
         );
+    }
+
+    // MARK: panic safety
+
+    #[test]
+    fn clear_panicking_drop_leaves_map_empty() {
+        let mut map = SkipMap::<u32, PanicOnDrop>::new();
+        for bomb in bombs(16, 15) {
+            map.insert(bomb.id(), bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| map.clear()));
+        assert!(result.is_err());
+
+        assert_eq!(map.len(), 0);
+        assert!(map.is_empty());
+        assert!(map.first_key_value().is_none());
+        assert!(map.last_key_value().is_none());
+        assert_eq!(map.iter().count(), 0);
+
+        map.insert(100, PanicOnDrop::new(100));
+        assert_eq!(map.last_key_value().map(|(k, _)| *k), Some(100));
+    }
+
+    /// The entries a panicking `clear` never reached stay in the map; they
+    /// must not be leaked, and a second `clear` must drop them.
+    #[test]
+    fn clear_panicking_drop_keeps_unreached_entries() {
+        let mut map = SkipMap::<u32, PanicOnDrop>::new();
+        for bomb in bombs(16, 7) {
+            map.insert(bomb.id(), bomb);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| map.clear()));
+        assert!(result.is_err());
+
+        let expected = [8, 9, 10, 11, 12, 13, 14, 15];
+        let keys: Vec<u32> = map.keys().copied().collect();
+        assert_eq!(keys, expected);
+        assert_eq!(map.len(), expected.len());
+        assert_eq!(map.last_key_value().map(|(k, _)| *k), Some(15));
+        for key in expected {
+            assert_eq!(map.get(&key).map(PanicOnDrop::id), Some(key));
+        }
+
+        map.clear();
+        assert!(map.is_empty());
     }
 }

--- a/src/skip_map/traits.rs
+++ b/src/skip_map/traits.rs
@@ -95,7 +95,7 @@ impl<K: Clone, V: Clone, C: Comparator<K> + Clone, G: LevelGenerator + Clone, co
         // SAFETY: self.head is a valid, live head sentinel. Every src_nn is a
         // live data node owned by self. new_head / prev_nn are exclusively
         // owned by new_map and have no other live references.
-        let tail = unsafe {
+        unsafe {
             let mut prev_nn = new_head;
             let mut src_opt = self.head.as_ref().next();
 
@@ -110,9 +110,14 @@ impl<K: Clone, V: Clone, C: Comparator<K> + Clone, G: LevelGenerator + Clone, co
                 src_opt = src_node.next();
             }
 
-            Node::rebuild(new_head)
-        };
-        new_map.tail = tail;
+            Node::filter_rebuild(
+                new_head,
+                &mut new_map.len,
+                &mut new_map.tail,
+                |_| true,
+                |_| {},
+            );
+        }
 
         new_map
     }

--- a/src/skip_set/filter.rs
+++ b/src/skip_set/filter.rs
@@ -14,6 +14,10 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> SkipSet<T, N, C, G>
     ///
     /// This operation runs in `$O(n)$` time.
     ///
+    /// If `f` or an element's destructor panics, the elements the walk had
+    /// not yet reached are kept in the set, as is the element `f` panicked
+    /// on; the set stays usable.
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/src/skip_set/structural.rs
+++ b/src/skip_set/structural.rs
@@ -17,6 +17,10 @@ impl<T, C: Comparator<T>, G: LevelGenerator, const N: usize> SkipSet<T, N, C, G>
     ///
     /// This operation is `$O(n)$`.
     ///
+    /// If an element's destructor panics, the remaining elements are kept in
+    /// the set rather than leaked, and the set stays usable; call `clear`
+    /// again to drop them.
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,71 @@
+//! Test-only helpers shared across the container test modules.
+
+use core::cmp::Ordering;
+
+/// An element whose destructor panics when armed.
+///
+/// Used to check that a container stays internally consistent when an element
+/// destructor unwinds while the container is midway through updating its own
+/// bookkeeping.  Ordering and equality use `id` alone, so comparisons never
+/// touch the armed flag and never panic.
+#[derive(Debug)]
+pub(crate) struct PanicOnDrop {
+    id: u32,
+    armed: bool,
+}
+
+impl PanicOnDrop {
+    /// An element whose destructor runs normally.
+    pub(crate) fn new(id: u32) -> Self {
+        Self { id, armed: false }
+    }
+
+    /// An element whose destructor panics.
+    pub(crate) fn armed(id: u32) -> Self {
+        Self { id, armed: true }
+    }
+
+    pub(crate) fn id(&self) -> u32 {
+        self.id
+    }
+}
+
+impl Drop for PanicOnDrop {
+    fn drop(&mut self) {
+        assert!(!self.armed, "PanicOnDrop({}) destructor fired", self.id);
+    }
+}
+
+impl PartialEq for PanicOnDrop {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for PanicOnDrop {}
+
+impl PartialOrd for PanicOnDrop {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PanicOnDrop {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+/// Builds `count` elements with ids `0..count`, arming the one at `armed`.
+///
+/// An `armed` of `count` or above matches no id, which is how callers ask
+/// for a run of elements whose destructors all pass.
+pub(crate) fn bombs(count: u32, armed: u32) -> impl Iterator<Item = PanicOnDrop> {
+    (0..count).map(move |i| {
+        if i == armed {
+            PanicOnDrop::armed(i)
+        } else {
+            PanicOnDrop::new(i)
+        }
+    })
+}


### PR DESCRIPTION
Eleven methods across SkipList, SkipMap and OrderedSkipList freed nodes while `self.len` and `self.tail` still described the pre-call list.  An element destructor or user predicate that panicked partway through escaped with those fields stale.  `self.tail` was then left pointing at freed memory whenever the freed set included the last node, and `back()` and `back_mut()` read through it.  `truncate(k)` for $k > 0$ additionally orphaned the unreached suffix: `Node::truncate_next` moved the chain into a local `Option<NonNull>`, which has no drop glue, so nothing freed it.

Two drop guards in `node.rs` carry the recovery.  `Rebuild` finishes the walk during unwind, retaining every node the operation never reached and publishing the resulting length and tail.  `DropChain` reattaches the unfreed remainder to the head sentinel and hands it to `Rebuild`.  Neither guard can panic, so no recovery path can abort the process by unwinding a second time.

The three `clear` implementations now detach the chain and commit `len`/`tail` before freeing anything, so the guard runs against a container that is already self-consistent.  Both `truncate`s do the same. `Node::filter_rebuild` takes `&mut len` and `&mut tail` out-parameters instead of returning a tuple, closing the window between "nodes freed" and "fields updated" that its callers used to hold open.

That signature change absorbs the two wrappers.  The tuple-returning `filter_rebuild` and the keep-all `rebuild` are gone; their call sites pass `|_| true, |_| {}` and the out-parameters directly.  Sites that previously relied on a comment asserting `len` was already correct now receive the length the walk counted.  `Node::truncate_next` has no remaining caller and is removed.

Elements the operation never reached stay reachable and are dropped normally when the container is.  Nothing leaks and nothing is dropped twice.

`ExtractIf` reaches the same rebuild through its `Drop`, so its two unwind paths are covered too: a predicate that panics mid-iteration, and an extracted element whose destructor panics while the iterator is still alive.  The rustdoc for every method that gained the guarantee now states it, including the `dedup`/`dedup_by_key` wrappers and the two `SkipSet` methods that inherit it by delegation.

Verified under Miri (1404 lib tests, no UB, no leaks) and under AddressSanitizer against reproducers for all eleven affected methods.

Reported-by: @tooson9010-spec
Fixes: GHSA-x6j6-3ffp-qrfr
